### PR TITLE
remove eth to wei conversions

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -21,9 +21,9 @@ var (
 	queueCapFlag = flag.Int("queuecap", 100, "Maximum transactions waiting to be sent")
 	versionFlag  = flag.Bool("version", false, "Print version number")
 
-	payoutFlag   = flag.Int("faucet.amount", 1, "Number of Ethers to transfer per user request")
+	payoutFlag   = flag.Int("faucet.amount", 1, "Number of Sequencer tokens to transfer per user request")
 	intervalFlag = flag.Int("faucet.minutes", 1440, "Number of minutes to wait between funding rounds")
-	netnameFlag  = flag.String("faucet.name", "testnet", "Network name to display on the frontend")
+	netnameFlag  = flag.String("faucet.name", "Astria Sequencer Network", "Network name to display on the frontend")
 
 	privKeyFlag  = flag.String("wallet.privkey", os.Getenv("PRIVATE_KEY"), "Private key hex to fund user requests with")
 	providerFlag = flag.String("wallet.provider", os.Getenv("WEB3_PROVIDER"), "Endpoint for Ethereum JSON-RPC connection")

--- a/internal/chain/util.go
+++ b/internal/chain/util.go
@@ -1,15 +1,8 @@
 package chain
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
 )
-
-func EtherToWei(amount int64) *big.Int {
-	ether := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
-	return new(big.Int).Mul(big.NewInt(amount), ether)
-}
 
 func Has0xPrefix(str string) bool {
 	return len(str) >= 2 && str[0] == '0' && (str[1] == 'x' || str[1] == 'X')

--- a/internal/chain/util_test.go
+++ b/internal/chain/util_test.go
@@ -1,8 +1,6 @@
 package chain
 
 import (
-	"math/big"
-	"reflect"
 	"testing"
 )
 
@@ -32,18 +30,22 @@ func TestIsValidAddress(t *testing.T) {
 	}
 }
 
-func TestEtherToWei(t *testing.T) {
+func TestHas0xPrefix(t *testing.T) {
+	type args struct {
+		str string
+	}
 	tests := []struct {
-		name   string
-		amount int64
-		want   *big.Int
+		name string
+		args args
+		want bool
 	}{
-		{name: "1ether", amount: 1, want: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)},
+		{name: "has 0x prefix", args: args{str: "0xab5801a7d398351b8be11c439e05c5b3259aec9b"}, want: true},
+		{name: "has no 0X prefix", args: args{str: "ab5801a7d398351b8be11c439e05c5b3259aec9b"}, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := EtherToWei(tt.amount); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("EtherToWei() = %v, want %v", got, tt.want)
+			if got := Has0xPrefix(tt.args.str); got != tt.want {
+				t.Errorf("Has0xPrefix() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -1,10 +1,14 @@
 package server
 
+import (
+	"math/big"
+)
+
 type Config struct {
 	network    string
 	httpPort   int
 	interval   int
-	payout     int
+	payout     *big.Int
 	proxyCount int
 	queueCap   int
 }
@@ -14,7 +18,7 @@ func NewConfig(network string, httpPort, interval, payout, proxyCount, queueCap 
 		network:    network,
 		httpPort:   httpPort,
 		interval:   interval,
-		payout:     payout,
+		payout:     big.NewInt(int64(payout)),
 		proxyCount: proxyCount,
 		queueCap:   queueCap,
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,7 +63,7 @@ func (s *Server) consumeQueue() {
 	defer s.mutex.Unlock()
 	for len(s.queue) != 0 {
 		address := <-s.queue
-		txHash, err := s.Transfer(context.Background(), address, chain.EtherToWei(int64(s.cfg.payout)))
+		txHash, err := s.Transfer(context.Background(), address, s.cfg.payout)
 		if err != nil {
 			log.WithError(err).Error("Failed to handle transaction in the queue")
 		} else {
@@ -102,7 +102,7 @@ func (s *Server) handleClaim() http.HandlerFunc {
 
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
-		txHash, err := s.Transfer(ctx, address, chain.EtherToWei(int64(s.cfg.payout)))
+		txHash, err := s.Transfer(ctx, address, s.cfg.payout)
 		s.mutex.Unlock()
 		if err != nil {
 			log.WithError(err).Error("Failed to send transaction")
@@ -128,7 +128,7 @@ func (s *Server) handleInfo() http.HandlerFunc {
 		renderJSON(w, infoResponse{
 			Account: s.Sender().String(),
 			Network: s.cfg.network,
-			Payout:  strconv.Itoa(s.cfg.payout),
+			Payout:  s.cfg.payout.String(),
 		}, http.StatusOK)
 	}
 }

--- a/web/src/Faucet.svelte
+++ b/web/src/Faucet.svelte
@@ -11,7 +11,7 @@
     payout: 1,
   };
 
-  $: document.title = `RIA ${capitalize(faucetInfo.network)} Faucet`;
+  $: document.title = `RIA ${faucetInfo.network} Faucet`;
 
   onMount(async () => {
     const res = await fetch('/api/info');
@@ -62,11 +62,6 @@
     let { msg } = await res.json();
     let type = res.ok ? 'is-success' : 'is-warning';
     toast({ message: msg, type });
-  }
-
-  function capitalize(str) {
-    const lower = str.toLowerCase();
-    return str.charAt(0).toUpperCase() + lower.slice(1);
   }
 </script>
 


### PR DESCRIPTION
The Sequencer network does not have the concept of wei, so this conversion was causing a large amount of Sequencer tokens to be transferred. 